### PR TITLE
Store the POSIXct `Sys.time()` stamp of when each message is pushed.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.1.0.9000
+
+- Store the POSIXct `Sys.time()` stamp of when each message is pushed.
+
 # Version 0.1.0
 
 - Add a new `$clean()` method to remove pushed messages from the database file.

--- a/R/txtq.R
+++ b/R/txtq.R
@@ -21,6 +21,8 @@
 #'   )
 #'   q$push(title = "Send back", message = "the sum.")
 #'   # See your queued messages.
+#'   # The `time` is the POSIXct `Sys.time()` stamp
+#'   # of when the message was pushed.
 #'   q$list()
 #'   q$count() # Number of messages in the queue.
 #'   q$total() # Number of messages that were ever queued.
@@ -133,6 +135,7 @@ R6_txtq <- R6::R6Class(
       out <- data.frame(
         title = base64url::base64_urlencode(as.character(title)),
         message = base64url::base64_urlencode(as.character(message)),
+        time = base64url::base64_urlencode(as.character(Sys.time())),
         stringsAsFactors = FALSE
       )
       new_total <- private$txtq_get_total() + nrow(out)
@@ -191,9 +194,10 @@ R6_txtq <- R6::R6Class(
       )
     },
     parse_db = function(x){
-      colnames(x) <- c("title", "message")
+      colnames(x) <- c("title", "message", "time")
       x$title <- base64url::base64_urldecode(x$title)
       x$message <- base64url::base64_urldecode(x$message)
+      x$time <- as.POSIXct(base64url::base64_urldecode(x$time))
       x
     }
   ),
@@ -241,5 +245,6 @@ R6_txtq <- R6::R6Class(
 null_log <- data.frame(
   title = character(0),
   message = character(0),
+  time = as.POSIXct(character(0)),
   stringsAsFactors = FALSE
 )

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,7 +31,7 @@ path # In real life, temp files go away when the session exits, so be careful.
 q <- txtq(path) # Create the queue.
 ```
 
-The queue uses text files to keep track of your data.
+The queue uses text files to keep track of your data. In the data frame of messages, the `time` column is the POSIXct `Sys.time()` stamp of when each message was pushed.
 
 ```{r files}
 list.files(q$path()) # The queue's underlying text files live in this folder.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,26 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+[![CRAN](https://www.r-pkg.org/badges/version/txtq)](https://cran.r-project.org/package=txtq) [![Travis build status](https://travis-ci.org/wlandau/txtq.svg?branch=master)](https://travis-ci.org/wlandau/txtq) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/wlandau/txtq?branch=master&svg=true)](https://ci.appveyor.com/project/wlandau/txtq) [![Codecov](https://codecov.io/github/wlandau/txtq/coverage.svg?branch=master)](https://codecov.io/github/wlandau/txtq?branch=master)
 
-[![CRAN](https://www.r-pkg.org/badges/version/txtq)](https://cran.r-project.org/package=txtq)
-[![Travis build
-status](https://travis-ci.org/wlandau/txtq.svg?branch=master)](https://travis-ci.org/wlandau/txtq)
-[![AppVeyor build
-status](https://ci.appveyor.com/api/projects/status/github/wlandau/txtq?branch=master&svg=true)](https://ci.appveyor.com/project/wlandau/txtq)
-[![Codecov](https://codecov.io/github/wlandau/txtq/coverage.svg?branch=master)](https://codecov.io/github/wlandau/txtq?branch=master)
+txtq - a small message queue for parallel processes
+===================================================
 
-# txtq - a small message queue for parallel processes
-
-The `txtq` package helps parallel R processes send messages to each
-other. Let’s say Process A and Process B are working on a parallel task
-together. First, both processes grab the queue.
+The `txtq` package helps parallel R processes send messages to each other. Let's say Process A and Process B are working on a parallel task together. First, both processes grab the queue.
 
 ``` r
 path <- tempfile() # Define a path to your queue.
 path # In real life, temp files go away when the session exits, so be careful.
-#> [1] "/tmp/RtmpxqsAqx/file62ca4dbdca58"
+#> [1] "/tmp/Rtmpt14rFr/file517839a8bfa2"
 q <- txtq(path) # Create the queue.
 ```
 
-The queue uses text files to keep track of your
-data.
+The queue uses text files to keep track of your data. In the data frame of messages, the `time` column is the POSIXct `Sys.time()` stamp of when each message was pushed.
 
 ``` r
 list.files(q$path()) # The queue's underlying text files live in this folder.
 #> [1] "db"    "head"  "lock"  "total"
 q$list() # You have not pushed any messages yet.
-#> [1] title   message
+#> [1] title   message time   
 #> <0 rows> (or 0-length row.names)
 ```
 
@@ -47,14 +39,14 @@ You can inspect the contents of the queue from either process.
 
 ``` r
 q$list()
-#>       title    message
-#> 1     Hello process B.
-#> 2 Calculate    sqrt(4)
-#> 3 Calculate   sqrt(16)
-#> 4 Send back   the sum.
+#>       title    message                time
+#> 1     Hello process B. 2018-10-09 22:04:08
+#> 2 Calculate    sqrt(4) 2018-10-09 22:04:08
+#> 3 Calculate   sqrt(16) 2018-10-09 22:04:08
+#> 4 Send back   the sum. 2018-10-09 22:04:08
 q$list(1) # You can specify the number of messages to list.
-#>   title    message
-#> 1 Hello process B.
+#>   title    message                time
+#> 1 Hello process B. 2018-10-09 22:04:08
 q$count()
 #> [1] 4
 ```
@@ -63,18 +55,18 @@ As Process A is pushing the messages, Process B can consume them.
 
 ``` r
 q$pop(2) # If you pass 2, you are assuming the queue has >=2 messages.
-#>       title    message
-#> 1     Hello process B.
-#> 2 Calculate    sqrt(4)
+#>       title    message                time
+#> 1     Hello process B. 2018-10-09 22:04:08
+#> 2 Calculate    sqrt(4) 2018-10-09 22:04:08
 ```
 
 Those popped messages are not technically in the queue any longer.
 
 ``` r
 q$list()
-#>       title  message
-#> 1 Calculate sqrt(16)
-#> 2 Send back the sum.
+#>       title  message                time
+#> 1 Calculate sqrt(16) 2018-10-09 22:04:08
+#> 2 Send back the sum. 2018-10-09 22:04:08
 q$count() # Number of messages technically in the queue.
 #> [1] 2
 ```
@@ -83,28 +75,27 @@ But we still have a full log of all the messages that were ever sent.
 
 ``` r
 q$log()
-#>       title    message
-#> 1     Hello process B.
-#> 2 Calculate    sqrt(4)
-#> 3 Calculate   sqrt(16)
-#> 4 Send back   the sum.
+#>       title    message                time
+#> 1     Hello process B. 2018-10-09 22:04:08
+#> 2 Calculate    sqrt(4) 2018-10-09 22:04:08
+#> 3 Calculate   sqrt(16) 2018-10-09 22:04:08
+#> 4 Send back   the sum. 2018-10-09 22:04:08
 q$total() # Number of messages that were ever queued.
 #> [1] 4
 ```
 
-Let’s let Process B get the rest of the instructions.
+Let's let Process B get the rest of the instructions.
 
 ``` r
 q$pop() # q$pop() with no arguments just pops one message.
-#>       title  message
-#> 1 Calculate sqrt(16)
+#>       title  message                time
+#> 1 Calculate sqrt(16) 2018-10-09 22:04:08
 q$pop() # Call q$pop(-1) to pop all the messages at once.
-#>       title  message
-#> 1 Send back the sum.
+#>       title  message                time
+#> 1 Send back the sum. 2018-10-09 22:04:08
 ```
 
-Now let’s say Process B follows the instructions in the messages. The
-last step is to send the results back to Process A.
+Now let's say Process B follows the instructions in the messages. The last step is to send the results back to Process A.
 
 ``` r
 q$push(title = "Results", message = as.character(sqrt(4) + sqrt(16)))
@@ -114,12 +105,11 @@ Process A can now see the results.
 
 ``` r
 q$pop()
-#>     title message
-#> 1 Results       6
+#>     title message                time
+#> 1 Results       6 2018-10-09 22:04:08
 ```
 
-The queue can grow large if you are not careful. Popped messages are
-kept in the database file.
+The queue can grow large if you are not careful. Popped messages are kept in the database file.
 
 ``` r
 q$push(title = "not", message = "popped")
@@ -128,20 +118,19 @@ q$count()
 q$total()
 #> [1] 6
 q$list()
-#>   title message
-#> 1   not  popped
+#>   title message                time
+#> 1   not  popped 2018-10-09 22:04:08
 q$log()
-#>       title    message
-#> 1     Hello process B.
-#> 2 Calculate    sqrt(4)
-#> 3 Calculate   sqrt(16)
-#> 4 Send back   the sum.
-#> 5   Results          6
-#> 6       not     popped
+#>       title    message                time
+#> 1     Hello process B. 2018-10-09 22:04:08
+#> 2 Calculate    sqrt(4) 2018-10-09 22:04:08
+#> 3 Calculate   sqrt(16) 2018-10-09 22:04:08
+#> 4 Send back   the sum. 2018-10-09 22:04:08
+#> 5   Results          6 2018-10-09 22:04:08
+#> 6       not     popped 2018-10-09 22:04:08
 ```
 
-To keep the database file from getting too big, you can clean out the
-popped messages.
+To keep the database file from getting too big, you can clean out the popped messages.
 
 ``` r
 q$clean()
@@ -150,11 +139,11 @@ q$count()
 q$total()
 #> [1] 1
 q$list()
-#>   title message
-#> 1   not  popped
+#>   title message                time
+#> 1   not  popped 2018-10-09 22:04:08
 q$log()
-#>   title message
-#> 1   not  popped
+#>   title message                time
+#> 1   not  popped 2018-10-09 22:04:08
 ```
 
 You can also reset the queue to remove all messages, popped or not.
@@ -166,10 +155,10 @@ q$count()
 q$total()
 #> [1] 0
 q$list()
-#> [1] title   message
+#> [1] title   message time   
 #> <0 rows> (or 0-length row.names)
 q$log()
-#> [1] title   message
+#> [1] title   message time   
 #> <0 rows> (or 0-length row.names)
 ```
 
@@ -181,39 +170,23 @@ file.exists(q$path())
 #> [1] FALSE
 ```
 
-This entire time, the queue was locked when either process was trying to
-create, access, or modify it. That way, the results stay correct even
-when multiple processes try to read or change the data at the same time.
+This entire time, the queue was locked when either process was trying to create, access, or modify it. That way, the results stay correct even when multiple processes try to read or change the data at the same time.
 
-# Similar work
+Similar work
+============
 
-## liteq
+liteq
+-----
 
-[Gábor Csárdi](https://github.com/gaborcsardi)’s
-[`liteq`](https://github.com/r-lib/liteq) package offers essentially the
-same functionality implemented with SQLite. It has a some additional
-features, such as the ability to detect crashed workers and re-queue
-failed messages, but it was in an early stage of development at the time
-`txtq` was released.
+[Gábor Csárdi](https://github.com/gaborcsardi)'s [`liteq`](https://github.com/r-lib/liteq) package offers essentially the same functionality implemented with SQLite. It has a some additional features, such as the ability to detect crashed workers and re-queue failed messages, but it was in an early stage of development at the time `txtq` was released.
 
-## Other message queues
+Other message queues
+--------------------
 
-There is a [plethora of message queues](http://queues.io/) beyond R,
-most notably [ZeroMQ](http://zeromq.org) and
-[RabbitMQ](https://www.rabbitmq.com/). In fact, [Jeroen
-Ooms](http://github.com/jeroen) and [Whit
-Armstrong](https://github.com/armstrtw) maintain
-[`rzmq`](https://github.com/ropensci/rzmq), a package to work with
-[ZeroMQ](http://zeromq.org) from R. Even in this landscape, `txtq` has
-advantages.
+There is a [plethora of message queues](http://queues.io/) beyond R, most notably [ZeroMQ](http://zeromq.org) and [RabbitMQ](https://www.rabbitmq.com/). In fact, [Jeroen Ooms](http://github.com/jeroen) and [Whit Armstrong](https://github.com/armstrtw) maintain [`rzmq`](https://github.com/ropensci/rzmq), a package to work with [ZeroMQ](http://zeromq.org) from R. Even in this landscape, `txtq` has advantages.
 
-1.  The `txtq` user interface is friendly, and its internals are simple.
-    No prior knowledge of sockets or message-passing is required.
-2.  `txtq` is lightweight, R-focused, and easy to install. It only
-    depends on R and a few packages on
-    [CRAN](https://cran.r-project.org).
+1.  The `txtq` user interface is friendly, and its internals are simple. No prior knowledge of sockets or message-passing is required.
+2.  `txtq` is lightweight, R-focused, and easy to install. It only depends on R and a few packages on [CRAN](https://cran.r-project.org).
 3.  Because `txtq` it is file-based,
-      - The queue persists even if your work crashes, so you can
-        diagnose failures with `q$log()` and `q$list()`.
-      - Job monitoring is easy. Just open another R session and call
-        `q$list()` while your work is running.
+    -   The queue persists even if your work crashes, so you can diagnose failures with `q$log()` and `q$list()`.
+    -   Job monitoring is easy. Just open another R session and call `q$list()` while your work is running.

--- a/man/txtq.Rd
+++ b/man/txtq.Rd
@@ -31,6 +31,8 @@ and the examples in this help file for instructions.
   )
   q$push(title = "Send back", message = "the sum.")
   # See your queued messages.
+  # The `time` is the POSIXct `Sys.time()` stamp
+  # of when the message was pushed.
   q$list()
   q$count() # Number of messages in the queue.
   q$total() # Number of messages that were ever queued.

--- a/tests/testthat/test-txtq.R
+++ b/tests/testthat/test-txtq.R
@@ -9,6 +9,7 @@ test_that("core txtq utilities work", {
   null_df <- data.frame(
     title = character(0),
     message = character(0),
+    time = as.POSIXct(character(0)),
     stringsAsFactors = FALSE
   )
   expect_equal(q$pop(), null_df)
@@ -29,22 +30,23 @@ test_that("core txtq utilities work", {
     message = c(2, 3, "\"128\"", "My sentence is not long."),
     stringsAsFactors = FALSE
   )
-  expect_equal(q$list(), full_df)
-  expect_equal(q$log(), full_df)
+  cols <- c("title", "message")
+  expect_equal(q$list()[, cols], full_df)
+  expect_equal(q$log()[, cols], full_df)
   o <- q$pop(1)
   expect_false(q$empty())
   expect_equal(q$count(), 3)
   expect_equal(q$total(), 4)
   expect_equal(q$list()$title, full_df[-1, "title"])
   expect_equal(q$list()$message, full_df[-1, "message"])
-  expect_equal(q$log(), full_df)
+  expect_equal(q$log()[, cols], full_df)
   out <- q$pop(-1)
   expect_equal(out$title, full_df[-1, "title"])
   expect_equal(out$message, full_df[-1, "message"])
   expect_true(q$empty())
   expect_equal(q$count(), 0)
   expect_equal(q$list(), null_df)
-  expect_equal(q$log(), full_df)
+  expect_equal(q$log()[, cols], full_df)
   q$push(title = "new", message = "message")
   expect_false(q$empty())
   expect_equal(q$count(), 1)
@@ -53,8 +55,8 @@ test_that("core txtq utilities work", {
     message = "message",
     stringsAsFactors = FALSE
   )
-  expect_equal(q$list(), one_df)
-  expect_equal(q$log(), rbind(full_df, one_df))
+  expect_equal(q$list()[, cols], one_df)
+  expect_equal(q$log()[, cols], rbind(full_df, one_df))
   expect_true(file.exists(q$path()))
   q$destroy()
   expect_false(file.exists(q$path()))
@@ -92,17 +94,18 @@ test_that("$clean()", {
       stringsAsFactors = FALSE
     )
   }
+  cols <- c("title", "message")
   q <- txtq(tempfile())
   q$push(title = as.character(1:5), message = letters[1:5])
-  expect_equal(q$pop(n = 2), df(index = 1:2))
-  expect_equal(q$list(), df(index = 3:5))
-  expect_equal(q$log(), df(index = 1:5))
+  expect_equal(q$pop(n = 2)[, cols], df(index = 1:2))
+  expect_equal(q$list()[, cols], df(index = 3:5))
+  expect_equal(q$log()[, cols], df(index = 1:5))
   expect_equal(q$count(), 3)
   expect_equal(q$total(), 5)
   for (i in 1:2){
     q$clean()
-    expect_equal(q$list(), df(index = 3:5))
-    expect_equal(q$log(), df(index = 3:5))
+    expect_equal(q$list()[, cols], df(index = 3:5))
+    expect_equal(q$log()[, cols], df(index = 3:5))
     expect_equal(q$count(), 3)
     expect_equal(q$total(), 3)
   }
@@ -134,9 +137,10 @@ test_that("txtq is thread safe", {
   parallel::stopCluster(cl)
   q <- txtq(in_)
   p <- txtq(out_)
+  cols <- c("title", "message")
   expect_equal(nrow(q$list()), 0)
   expect_equal(nrow(q$log()), 1000)
   expect_equal(nrow(p$log()), 1000)
-  expect_equal(p$list(), q$log())
-  expect_equal(p$list(), p$log())
+  expect_equal(p$list()[, cols], q$log()[, cols])
+  expect_equal(p$list()[, cols], p$log()[, cols])
 })


### PR DESCRIPTION
``` r
library(txtq)
q <- txtq(tempfile())
q$push("messages", "have")
Sys.sleep(2)
q$push("timestamps", "now")
q$list()
#>        title message                time
#> 1   messages    have 2018-10-09 22:05:31
#> 2 timestamps     now 2018-10-09 22:05:33
str(q$list())
#> 'data.frame':    2 obs. of  3 variables:
#>  $ title  : chr  "messages" "timestamps"
#>  $ message: chr  "have" "now"
#>  $ time   : POSIXct, format: "2018-10-09 22:05:31" "2018-10-09 22:05:33"
```

<sup>Created on 2018-10-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

cc @kendonB. My only concern with this change is its incompatibility with old `txtq`s. @fellstat, do you think it is likely to break existing workflows?